### PR TITLE
Fixed to work with /usr/local/bin/python instead of /usr/bin/python on newer macOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 
 **Read [disclaimer](#disclaimer) before using this software.*
 ## About this fork
+* Fixed to work with /usr/local/bin/python instead of /usr/bin/python on newer macOS.
 * A8/A9 ipwndfu support by @a1exdandy
 * this fork is fork of @a1exdandy A8 and A9 ipwndfu which allows loading of unsigned IMG4 files on t7000, s8000 and s8003 devices.
 * Run  ```./ipwndfu -p --rmsigchecks```.

--- a/ibootpatcher
+++ b/ibootpatcher
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/local/bin/python
 # ibootpatcher: patch assembly code in iBoot binaries
 # Author: axi0mX
 

--- a/ipwndfu
+++ b/ipwndfu
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/local/bin/python
 # ipwndfu: open-source jailbreaking tool for older iOS devices
 # Author: axi0mX
 

--- a/ipwnrecovery
+++ b/ipwnrecovery
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/local/bin/python
 # ipwnrecovery: open-source jailbreaking tool for older iOS devices
 # Author: axi0mX
 


### PR DESCRIPTION
Fixed to work with /usr/local/bin/python instead of /usr/bin/python which is no longer available on newer macOS, especially via Homebrew.

Fixes the "bad interpreter /usr/bin/python no such file or directory".
